### PR TITLE
Parsing string literals and comments

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -48,7 +48,7 @@ record { VariableDeclaration } end
 ```
 array [ Expression ] Type
 ```
-**Body : **  SimpleDeclaration | Statement
+**Body :**  SimpleDeclaration | Statement
 **Statement :**
 > Assignment
 RoutineCall
@@ -61,7 +61,7 @@ IfStatement
 ```
 ModifiablePrimary := Expression
 ```
-**RoutineCall : **
+**RoutineCall :**
 ```
 Identifier [ ( Expression { , Expression } ) ]
 ```
@@ -72,7 +72,7 @@ loop
 Body
 end
 ```
-**ForLoop : **
+**ForLoop :**
 ```
 for Identifier Range
 loop
@@ -119,7 +119,7 @@ __Summand :__ Primary | ( Expression )
 - Menna Awadallah
 - Mosab Mohamed
 ## Code example:
-
+PS: 
 ```
 type int is integer;
 routine main () : int is

--- a/lexer.l
+++ b/lexer.l
@@ -28,6 +28,7 @@ enum token_type {
     TK_ELSE,
     TK_IN,
     TK_REVERSE,
+    TK_STRING_LITERAL,
     TK_IDENTIFIER,
     TK_DOUBLE_LITERAL,
     TK_INTEGER_LITERAL,
@@ -128,7 +129,6 @@ Token newToken(token_type type, string value) {
 "]"                     cout << "TK_RSQBRK" << " ";
 "{"                     cout << "TK_LBRACK" << " ";
 "}"                     cout << "TK_RBRACK" << " ";
-"'"                     cout << "TK_SQUOT" << " ";
 "."                     cout << "TK_DOT" << " "; 
 ","                     cout << "TK_COMMA" << " ";
 ":"                     cout << "TK_COLON" << " ";
@@ -144,7 +144,10 @@ Token newToken(token_type type, string value) {
 "and"                   cout << "TK_AND" << " "; 
 "or"                    cout << "TK_OR" << " "; 
 "xor"                   cout << "TK_XOR" << " ";
-[a-zA-Z_][a-zA-Z0-9_]*  cout << "TK_IDENTIFIER" << " "; 
+\"([^\\\"]|\\.)*\"      cout << "TK_STRING_LITERAL" << " "; /*TODO: new_token*/
+\'([^\\\"]|\\.)*\'      cout << "TK_STRING_LITERAL" << " "; /*TODO: new_token*/
+\/\/(.*)                cout << "TK_COMMENT" << " "; /*TODO: will ignore and do nothing*/
+[a-zA-Z_][a-zA-Z0-9_]*  cout << "TK_IDENTIFIER" << " ";   /*TODO: new_token*/
 [0-9]+\.[0-9]+          cout << "TK_DOUBLE_LITERAL" << " "; 
 [0-9]+                  cout << "TK_INTEGER_LITERAL" << " "; 
 '.'                     cout << "TK_CHARACTER_LITERAL" << " "; 

--- a/tests/valid_tests/1.crbc
+++ b/tests/valid_tests/1.crbc
@@ -2,3 +2,4 @@ routine main () : integer is
     print('Hello world\n');
     return 0;
 end
+//test

--- a/tests/valid_tests/3.crbc
+++ b/tests/valid_tests/3.crbc
@@ -2,9 +2,10 @@ type int is integer;
 routine main () : int is
    var x : int is (7 + 9);
    if (x > 9) then
-        print('X is bigger than 9');
+        print("X is bigger than '9\n");
     else
-        print('X is not bigger than 9');
+        print('X is not bigger than '9\n');
+        print('\n');
     end
    return 0;
 end

--- a/tests/valid_tests/4.crbc
+++ b/tests/valid_tests/4.crbc
@@ -5,7 +5,7 @@ routine main () : int is
         if (i >= 9) then
             print('I is bigger than or equal 9\n');
         else
-            print('I is not bigger than 9\n');
+            print("I is not bigger than 9\n");
         end
     end
    return 0;

--- a/tests/valid_tests/5.crbc
+++ b/tests/valid_tests/5.crbc
@@ -4,7 +4,7 @@ routine main () : int is
     while (i < 13)
     loop
         if (i >= 9) then
-            print('I is bigger than or equal 9\n');
+            print("I is bigger than or equal 9\n");
         else
             print('I is not bigger than 9\n');
         end

--- a/tests/valid_tests/6.crbc
+++ b/tests/valid_tests/6.crbc
@@ -1,0 +1,14 @@
+type int is integer;
+routine main () : int is
+    var a : array [6] int is [1, 2, 3, 4, 5, 6];
+    // please note that i value is read only and not modifable
+    for each i from a:
+    loop
+        if (i >= 3) then
+            print("I is bigger than or equal 3\n");
+        else
+            print('I is not bigger than 3\n');
+        end
+    end
+   return 0;
+end

--- a/tests/valid_tests/tests_description.txt
+++ b/tests/valid_tests/tests_description.txt
@@ -5,5 +5,6 @@
 3. If else condition was added in addition to 2.
 4. For loop was added in addition to 3.
 5. While loop replaced the for loop in 4 and variable assignment was added.
+6. For each loop with array and comment.
 7. Simple record decleration with printing its content and performing arithmetic operations on them.
 8. Simple array decleration that uses for loop to print its content. 


### PR DESCRIPTION
Lexer can now tokenize string literals in the format of "STRING" or 'STRING'. Fruthermore, both formats of string literals may contain ' as a normal character inside of it' Example: "string's". Lexer can now also tokenize one line comments