### PR TITLE
Semantics cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ parser
 *.o
 lexer.cpp
 *.out
-**./outputs/
+tests/outputs/
+build/

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ full_lexer:
 full_parser:
 	flex -o lexer.cpp -i lexer.l
 	bison -d parser.ypp -o parser.cpp
-	g++ -g main.cpp lexer.cpp parser.cpp driver.cpp astPrinter.cpp prettyPrinter.cpp -o output.out 
+	g++ -g main.cpp lexer.cpp parser.cpp driver.cpp astPrinter.cpp prettyPrinter.cpp semantic.cpp -o output.out 
 	./output.out < test.crbc
-
 # Tests 
 test:
 	bash test.sh

--- a/ast.hpp
+++ b/ast.hpp
@@ -117,6 +117,11 @@ namespace ast
     {
     public:
         virtual void accept(Visitor *v) = 0;
+        virtual bool operator==(const Visitable& rhs) const
+        {
+            std::cout<<"This should never run\n";
+            return false;
+        }
     };
 
     class Program : public Visitable
@@ -285,20 +290,35 @@ namespace ast
     {
     public:
         void accept(Visitor *v) override { v->visitIntegerType(this); }
+        virtual bool operator==(const Visitable& rhs) const override
+        {
+            if(dynamic_cast<const IntegerType*>(&rhs))
+                return true;
+            return false;
+        }
     };
-
     class RealType : public PrimitiveType
     {
     public:
         void accept(Visitor *v) override { v->visitRealType(this); }
+        virtual bool operator==(const Visitable& rhs) const override
+        {
+            if(dynamic_cast<const RealType*>(&rhs))
+                return true;
+            return false;
+        }
     };
-
     class BooleanType : public PrimitiveType
     {
     public:
         void accept(Visitor *v) override { v->visitBooleanType(this); }
+        virtual bool operator==(const Visitable& rhs) const override
+        {
+            if(dynamic_cast<const BooleanType*>(&rhs))
+                return true;
+            return false;
+        }
     };
-
     class ArrayType : public UserType
     {
     public:
@@ -306,14 +326,14 @@ namespace ast
         Expr *size = nullptr;
         ArrayType(Type *type, Expr *size) : type(type), size(size) {}
         void accept(Visitor *v) override { v->visitArrayType(this); }
-    };
-
-    class RecordType : public UserType
-    {
-    public:
-        LocalVarList *decls;
-        RecordType(LocalVarList *decls) : decls(decls) {}
-        void accept(Visitor *v) override { v->visitRecordType(this); }
+        virtual bool operator==(const Visitable& rhs) const override
+        {
+            if(auto array_type = dynamic_cast<const ArrayType*>(&rhs)){
+                if(array_type->size == this->size && (*array_type->type) == (*this->type) )
+                    return true;
+            }
+            return false;
+        }
     };
 
     class ParameterDecl : public Decl
@@ -355,6 +375,15 @@ namespace ast
         Expr *init = nullptr;
         LocalVarDecl(Ident name, Type *type, Expr *init) : name(name), type(type), init(init) {}
         void accept(Visitor *v) override { v->visitLocalVarDecl(this); }
+        virtual bool operator==(const Visitable& rhs) const override
+        {
+            if(auto local_var_decl = dynamic_cast<const LocalVarDecl*>(&rhs)){  
+                if(local_var_decl->name == this->name && (*local_var_decl->type) == (*this->type) ){
+                    return true;
+                }
+            }
+            return false;
+        }
     };
 
     class LocalVarList : public Visitable
@@ -363,6 +392,42 @@ namespace ast
         std::vector<LocalVarDecl *> vars = {};
         LocalVarList(std::vector<LocalVarDecl *> vars) : vars(vars) {}
         void accept(Visitor *v) override { v->visitLocalVarList(this); }
+        virtual bool operator==(const Visitable& rhs) const override
+        {
+            if(auto local_var_list = dynamic_cast<const LocalVarList*>(&rhs)){
+                int found = 0;
+                for(int i = 0; i < this->vars.size(); i++){
+                    auto x = (*this->vars[i]);
+                    for(int j = 0; j < local_var_list->vars.size(); j ++){
+                        if(x == *local_var_list->vars[j]){
+                            found++;
+                            break;
+                        }
+                    }
+                }
+                if(this->vars.size() != local_var_list->vars.size()){
+                    return false;
+                }
+                return (found == this->vars.size());
+            }
+            return false;
+        }
+            
+    };
+    class RecordType : public UserType
+    {
+    public:
+        LocalVarList *decls;
+        RecordType(LocalVarList *decls) : decls(decls) {}
+        void accept(Visitor *v) override { v->visitRecordType(this); }
+        virtual bool operator==(const Visitable& rhs) const override
+        {
+            if(auto record_type = dynamic_cast<const RecordType*>(&rhs)){
+                if( (*(record_type->decls)) == (*(this->decls)) )
+                    return true;
+            }
+            return false;
+        }
     };
 
     class Statement : public BodyEntity

--- a/ast.hpp
+++ b/ast.hpp
@@ -430,7 +430,8 @@ namespace ast
     public:
         Expr *from = nullptr;
         Expr *to = nullptr;
-        Range(Expr *from, Expr *to) : from(from), to(to) {}
+        bool reverse = false;
+        Range(Expr *from, Expr *to, bool reverse) : from(from), to(to), reverse(reverse) {}
         void accept(Visitor *v) override { v->visitRange(this); }
     };
 

--- a/ast.hpp
+++ b/ast.hpp
@@ -398,11 +398,15 @@ namespace ast
                 int found = 0;
                 for(int i = 0; i < this->vars.size(); i++){
                     auto x = (*this->vars[i]);
-                    for(int j = 0; j < local_var_list->vars.size(); j ++){
-                        if(x == *local_var_list->vars[j]){
-                            found++;
-                            break;
-                        }
+                    // for(int j = 0; j < local_var_list->vars.size(); j ++){
+                    //     if(x == *local_var_list->vars[j]){
+                    //         found++;
+                    //         break;
+                    //     }
+                    // }
+                    if(i < local_var_list->vars.size()){
+                        if(x == *local_var_list->vars[i])
+                             found++;
                     }
                 }
                 if(this->vars.size() != local_var_list->vars.size()){

--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     // program->accept(&printer);
     analyzer::Semantic analyzer;
     program->accept(&analyzer);
-    // prettyPrinter::codePrinter printer;
-    // program->accept(&printer);
+    //prettyPrinter::codePrinter printer;
+    //program->accept(&printer);
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,6 @@
 #include "parser.hpp"
 #include "ast.hpp"
 #include "astPrinter.hpp"
-#include "prettyPrinter.hpp"
 #include "semantic.hpp"
 extern ast::Program *program;
 
@@ -17,9 +16,9 @@ int main(int argc, char **argv)
     std::cout << std::endl;
     // analyzer::AstPrinter printer;
     // program->accept(&printer);
-     analyzer::Semantic analyzer;
-     program->accept(&analyzer);
-    //prettyPrinter::codePrinter printer;
-    //program->accept(&printer);
+    analyzer::Semantic analyzer;
+    program->accept(&analyzer);
+    // prettyPrinter::codePrinter printer;
+    // program->accept(&printer);
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,7 @@
 #include "ast.hpp"
 #include "astPrinter.hpp"
 #include "prettyPrinter.hpp"
-
+#include "semantic.hpp"
 extern ast::Program *program;
 
 int main(int argc, char **argv)
@@ -17,9 +17,9 @@ int main(int argc, char **argv)
     std::cout << std::endl;
     // analyzer::AstPrinter printer;
     // program->accept(&printer);
-    // analyzer::Semantic analyzer;
-    // program->accept(&analyzer);
-    prettyPrinter::codePrinter printer;
-    program->accept(&printer);
+     analyzer::Semantic analyzer;
+     program->accept(&analyzer);
+    //prettyPrinter::codePrinter printer;
+    //program->accept(&printer);
     return 0;
 }

--- a/parser.ypp
+++ b/parser.ypp
@@ -195,8 +195,8 @@ FOR_LOOP:
     TK_FOR TK_IDENTIFIER TK_IN RANGE TK_LOOP BODY TK_END{ $$ = new ast::ForLoop($2, $4, $6); }
     ;
 RANGE:
-    EXPR TK_DDOT EXPR { $$ = new ast::Range($1, $3); }
-    | TK_REVERSE EXPR TK_DDOT EXPR { $$ = new ast::Range($4, $2); }
+    EXPR TK_DDOT EXPR { $$ = new ast::Range($1, $3, false); }
+    | TK_REVERSE EXPR TK_DDOT EXPR { $$ = new ast::Range($2, $4, true); }
     ;
 RETURN: 
     TK_RETURN EXPR TK_SEMICOLON { $$ = new ast::Return($2); }

--- a/prettyPrinter.cpp
+++ b/prettyPrinter.cpp
@@ -34,6 +34,11 @@ namespace prettyPrinter
         }
     }
 
+    void codePrinter::print(ast::Visitable *v)
+    {
+        v->accept(this);
+    }
+
     void codePrinter::visitProgram(ast::Program *p)
     {
         for (auto &decl : p->decls)
@@ -372,6 +377,8 @@ namespace prettyPrinter
 
     void codePrinter::visitRange(ast::Range *p)
     {
+        if (p->reverse)
+            cout << "reverse ";
         if (p->from != nullptr)
             p->from->accept(this);
         cout << " .. ";

--- a/prettyPrinter.hpp
+++ b/prettyPrinter.hpp
@@ -57,6 +57,7 @@ namespace prettyPrinter
         void visitBoolean(ast::Boolean x) override;
         void visitIdent(ast::Ident x) override;
 
+        void print(ast::Visitable *v);
     private:
         size_t depth;
         void indent();

--- a/semantic.cpp
+++ b/semantic.cpp
@@ -213,7 +213,7 @@ namespace analyzer
             size2 = routine->params->decls.size();
         }
         if(size1 != size2){
-            err_wrong_params_number(size1, size2);
+            err_wrong_params_number(size2, size1);
         }
         if(node->args && routine->params){
             for (int i = 0; i < node->args->exprs.size(); i++){
@@ -223,7 +223,7 @@ namespace analyzer
                         node->args->exprs[i]->accept(this);
                     }
                     if(actual_type){
-                        typecheck_types(actual_type,routine->params->decls[i]->type);
+                        typecheck_types(routine->params->decls[i]->type, actual_type);
                     }
                 }
             }
@@ -251,7 +251,7 @@ namespace analyzer
             node->condition->accept(this);
         }
         cond_type = actual_type;
-        typecheck_types(cond_type, new ast::BooleanType());
+        typecheck_types(new ast::BooleanType(), cond_type);
         if (node->then)
         {
             node->then->accept(this);
@@ -269,7 +269,7 @@ namespace analyzer
             node->condition->accept(this);
         }
         cond_type = actual_type;
-        typecheck_types(cond_type, new ast::BooleanType());
+        typecheck_types(new ast::BooleanType(), cond_type);
         if (node->body)
         {
             node->body->accept(this);
@@ -299,8 +299,8 @@ namespace analyzer
             node->to->accept(this);
         }
         toType = actual_type;
-        typecheck_types(fromType, new ast::IntegerType());
-        typecheck_types(toType, new ast::IntegerType());
+        typecheck_types(new ast::IntegerType(), fromType);
+        typecheck_types(new ast::IntegerType(), toType);
     }
     void Semantic::visitPrint(ast::Print *node)
     {
@@ -432,13 +432,13 @@ namespace analyzer
         std::string got_type = type_to_string(my_current_type);
         if (got_type.substr(0, 5) != "Array")
         {
-            err_expected_got(got_type, "Array");
+            err_expected_got("Array", got_type);
         }
         else
         {
             auto access_value = node->index;
             access_value->accept(this);
-            typecheck_types(actual_type, new ast::IntegerType());
+            typecheck_types(new ast::IntegerType(), actual_type);
             if(auto casted_type = dynamic_cast<ast::ArrayType *>(my_current_type)){
                 current_var_type = casted_type->type;
             }
@@ -452,7 +452,7 @@ namespace analyzer
         std::string got_type = type_to_string(my_current_type);
         if (got_type.substr(0, 6) != "Record")
         {
-            err_expected_got(got_type, "Record");
+            err_expected_got("Record", got_type);
         }
         else
         {
@@ -479,14 +479,6 @@ namespace analyzer
         {
             err_undefined_obj(node->name);
         }
-        // for (auto arg : node->args->exprs)
-        // {
-        //     if (arg)
-        //     {
-        //         arg->accept(this);
-                
-        //     }
-        // }
         auto routine = routineDeclTable[node->name];
         int size1 = 0, size2 = 0;
         if(node->args){
@@ -496,7 +488,7 @@ namespace analyzer
             size2 = routine->params->decls.size();
         }
         if(size1 != size2){
-            err_wrong_params_number(size1, size2);
+            err_wrong_params_number(size2, size1);
         }
         if(node->args && routine->params){
             for (int i = 0; i < node->args->exprs.size(); i++){
@@ -506,7 +498,7 @@ namespace analyzer
                         node->args->exprs[i]->accept(this);
                     }
                     if(actual_type){
-                        typecheck_types(actual_type,routine->params->decls[i]->type);
+                        typecheck_types(routine->params->decls[i]->type, actual_type);
                     }
                 }
             }

--- a/semantic.cpp
+++ b/semantic.cpp
@@ -65,7 +65,7 @@ namespace analyzer
         node->returnType = ret_type;
         routineDeclTable[node->name] = node;
         if (routine_return_type && ret_type)
-            typecheck_types(routine_return_type, ret_type);
+            typecheck_types(ret_type, routine_return_type);
 
         remove_params_from_scope();
     };

--- a/semantic.cpp
+++ b/semantic.cpp
@@ -98,7 +98,6 @@ namespace analyzer
             node->type->accept(this);
         }
         ast::Type *var_type = actual_type;
-        //std::cout<<"I'm a param and my name is " << node->name << " and type is " << type_to_string(var_type) << '\n';
         varDeclSymbolTable[node->name] = var_type;
         varStack.push_back({node->name, var_type});
         routine_vars_n ++ ;
@@ -171,8 +170,6 @@ namespace analyzer
         {
             var_type = expr_type;
         }
-        //std::cout<<"I'm a var and my name is " << node->name << " and type is " << type_to_string(var_type) << '\n';
-        //std::cout<<"Expression type is " << type_to_string(expr_type) << '\n';
         varDeclSymbolTable[node->name] = var_type;
         varStack.push_back({node->name, var_type});
         routine_vars_n ++;
@@ -192,8 +189,6 @@ namespace analyzer
         }
         rhs_type = actual_type;
         typecheck_types(lhs_type, rhs_type);
-        std::cout <<node->var->name << '\n';
-        std::cout<<type_to_string(lhs_type) << ' ' << type_to_string(rhs_type) << '\n';
     };
     void Semantic::visitRoutineCall(ast::RoutineCall *node)
     {
@@ -422,7 +417,6 @@ namespace analyzer
             err_undefined_obj(node->name);
         }
         current_var_type = varDeclSymbolTable[node->name];
-        //std::cout<<"I'm current var type: " << type_to_string(current_var_type) << '\n';
         if(node->accesses){
             for (auto AV : node->accesses->accesses)
             {
@@ -430,8 +424,6 @@ namespace analyzer
                     AV->accept(this);
             }
         }
-        //std::cout<< node->name << '\n';
-        //std::cout<<"I'm current var type: " << type_to_string(current_var_type) << '\n';
         actual_type = current_var_type;
     };
     void Semantic::visitArrayAccess(ast::ArrayAccess* node){
@@ -449,7 +441,6 @@ namespace analyzer
             typecheck_types(actual_type, new ast::IntegerType());
             if(auto casted_type = dynamic_cast<ast::ArrayType *>(my_current_type)){
                 current_var_type = casted_type->type;
-                std::cout<<"current var type : " << type_to_string(my_current_type) << '\n';
             }
         }
 
@@ -482,4 +473,43 @@ namespace analyzer
             }
         }
     }
+     void Semantic::visitRoutineCallValue(ast::RoutineCallValue *node)
+    {
+        if (routineDeclTable.find(node->name) == routineDeclTable.end())
+        {
+            err_undefined_obj(node->name);
+        }
+        // for (auto arg : node->args->exprs)
+        // {
+        //     if (arg)
+        //     {
+        //         arg->accept(this);
+                
+        //     }
+        // }
+        auto routine = routineDeclTable[node->name];
+        int size1 = 0, size2 = 0;
+        if(node->args){
+            size1 = node->args->exprs.size();
+        }
+        if(routine->params){
+            size2 = routine->params->decls.size();
+        }
+        if(size1 != size2){
+            err_wrong_params_number(size1, size2);
+        }
+        if(node->args && routine->params){
+            for (int i = 0; i < node->args->exprs.size(); i++){
+                if(routine->params->decls[i]->type && node->args->exprs[i]){
+                    if(node->args->exprs[i]){
+                        actual_type = nullptr;
+                        node->args->exprs[i]->accept(this);
+                    }
+                    if(actual_type){
+                        typecheck_types(actual_type,routine->params->decls[i]->type);
+                    }
+                }
+            }
+        }
+    };
 }

--- a/semantic.cpp
+++ b/semantic.cpp
@@ -196,14 +196,6 @@ namespace analyzer
         {
             err_undefined_obj(node->name);
         }
-        // for (auto arg : node->args->exprs)
-        // {
-        //     if (arg)
-        //     {
-        //         arg->accept(this);
-                
-        //     }
-        // }
         auto routine = routineDeclTable[node->name];
         int size1 = 0, size2 = 0;
         if(node->args){

--- a/semantic.cpp
+++ b/semantic.cpp
@@ -4,75 +4,67 @@
 
 namespace analyzer
 {
-    void Semantic::visit(ast::Program *node)
+    void Semantic::visitProgram(ast::Program *node)
     {
-        for (auto type : node->types)
+        for (auto decl : node->decls)
         {
-            if (type)
+            if (decl)
             {
-                type->accept(this);
-            }
-        }
-        for (auto variable : node->variables)
-        {
-            if(variable)
-            {
-                variable->accept(this);
-            }
-        }
-        for (auto routine : node->routines)
-        {
-            if (routine)
-            {
-                routine->accept(this);
+                decl->accept(this);
             }
         }
     };
-    void Semantic::visit(ast::TypeDeclaration *node)
+    void Semantic::visitTypeDecl(ast::TypeDecl *node)
     {
-        if (typeDeclSymbolTable.find(node->name) != typeDeclSymbolTable.end() ||
-        varDeclSymbolTable.count(node->name) || routineDeclTable.count(node->name))
+        if (typeDeclSymbolTable.count(node->name->name) ||
+        varDeclSymbolTable.count(node->name->name) ||
+        routineDeclTable.count(node->name->name))
         {
-            err_second_declaration(node->name);
+            err_second_declaration(node->name->name);
         }
         ast::Type *type;
-        if (node->dtype)
+        if (node->type)
         {
-            node->dtype->accept(this);
+            actual_type = nullptr;
+            node->type->accept(this);
         }
         type = actual_type;
-        typeDeclSymbolTable[node->name] = type;
+        typeDeclSymbolTable[node->name->name] = type;
     };
-    void Semantic::visit(ast::RoutineDeclaration *node)
+    void Semantic::visitRoutineDecl(ast::RoutineDecl *node)
     {
         routine_vars_n = 0;
         routine_return_type = nullptr;
         ast::Type *ret_type = nullptr;
-        if (routineDeclTable.find(node->name) != routineDeclTable.end() ||
-        varDeclSymbolTable.count(node->name) || typeDeclSymbolTable.count(node->name))
+        if (routineDeclTable.count(node->name) ||
+        varDeclSymbolTable.count(node->name) ||
+        typeDeclSymbolTable.count(node->name))
         {
             err_second_declaration(node->name);
         }
-        for (auto parameter : node->params)
-        {
-            if (parameter)
+        if(node->params){
+            for (auto parameter : node->params->decls)
             {
-                parameter->accept(this);
+                if (parameter)
+                {
+                    parameter->accept(this);
+                }
             }
         }
-        if (node->rtype)
+        if (node->returnType)
         {
-            node->rtype->accept(this);
+            actual_type = nullptr;
+            node->returnType->accept(this);
         }
         ret_type = actual_type;
         if (node->body)
         {
             node->body->accept(this);
         }
-        node->rtype = TypePointerToShared(ret_type); 
+        node->returnType = ret_type; 
         routineDeclTable[node->name] = node;
         if(routine_return_type && ret_type)
-            typecheck_types(&(*routine_return_type), ret_type);
+            typecheck_types(routine_return_type, ret_type);
         while(routine_vars_n -- ){
             if(varStack.size()){
                 std::string delVar = varStack[varStack.size()-1].first;
@@ -90,249 +82,173 @@ namespace analyzer
             }
         }
     };
-    void Semantic::visit(ast::VariableDeclaration *node)
-    {
-        if (typeDeclSymbolTable.find(node->name) != typeDeclSymbolTable.end() 
+    void Semantic::visitParameterDecl(ast::ParameterDecl* node){
+        if (typeDeclSymbolTable.count(node->name) 
                     || routineDeclTable.count(node->name))
         {
             err_second_declaration(node->name);
         }
-        if (varDeclSymbolTable.find(node->name) != varDeclSymbolTable.end())
+        if (varDeclSymbolTable.count(node->name))
         {
             warn_shadow(node->name);
         }
-        if (node->dtype)
+        if (node->type)
         {
-            node->dtype->accept(this);
+            actual_type = nullptr;
+            node->type->accept(this);
         }
         ast::Type *var_type = actual_type;
-        if (node->initial_value)
+        //std::cout<<"I'm a param and my name is " << node->name << " and type is " << type_to_string(var_type) << '\n';
+        varDeclSymbolTable[node->name] = var_type;
+        varStack.push_back({node->name, var_type});
+        routine_vars_n ++ ;
+    }
+    void Semantic::visitGlobalVarDecl(ast::GlobalVarDecl *node)
+    {
+        if (typeDeclSymbolTable.count(node->name) ||
+         routineDeclTable.count(node->name)|| 
+         varDeclSymbolTable.count(node->name))
         {
-            node->initial_value->accept(this);
+            err_second_declaration(node->name);
+        }
+        if (node->type)
+        {
+            actual_type = nullptr;
+            node->type->accept(this);
+        }
+        ast::Type *var_type = actual_type;
+        if (node->init)
+        {
+            node->init->accept(this);
         }
         ast::Type *expr_type = actual_type;
-        if (node->dtype && node->initial_value)
+        if (node->type && node->init)
         {
             typecheck_types(var_type, expr_type);
         }
-        else if (node->initial_value)
+        else if (node->init)
         {
             var_type = expr_type;
         }
         varDeclSymbolTable[node->name] = var_type;
         varStack.push_back({node->name, var_type});
+    };
+    void Semantic::visitBody(ast::Body *node)
+    {   
+        for (auto entity : node->entities){
+            if(entity){
+                entity->accept(this);
+            }
+        }
+    };
+    void Semantic::visitLocalVarDecl(ast::LocalVarDecl *node)
+    {
+        if (typeDeclSymbolTable.count(node->name) 
+                    || routineDeclTable.count(node->name))
+        {
+            err_second_declaration(node->name);
+        }
+        if (varDeclSymbolTable.count(node->name))
+        {
+            warn_shadow(node->name);
+        }
+        if (node->type)
+        {
+            actual_type = nullptr;
+            node->type->accept(this);
+        }
+        ast::Type *var_type = actual_type;
+        if (node->init)
+        {
+            node->init->accept(this);
+        }
+        ast::Type *expr_type = actual_type;
+        if (var_type && expr_type)
+        {
+            typecheck_types(var_type, expr_type);
+        }
+        else if (expr_type)
+        {
+            var_type = expr_type;
+        }
+        //std::cout<<"I'm a var and my name is " << node->name << " and type is " << type_to_string(var_type) << '\n';
+        //std::cout<<"Expression type is " << type_to_string(expr_type) << '\n';
+        varDeclSymbolTable[node->name] = var_type;
+        varStack.push_back({node->name, var_type});
         routine_vars_n ++;
     };
-    void Semantic::visit(ast::Body *node)
-    {
-        for (auto variableDecl : node->variables)
-        {
-            if (variableDecl)
-            {
-                variableDecl->accept(this);
-            }
-        }
-
-        for (auto statement : node->statements)
-        {
-            if (statement)
-            {
-                statement->accept(this);
-            }
-        }
-    };
-    void Semantic::visit(ast::IntType *node)
-    {
-        actual_type = node;
-    };
-    void Semantic::visit(ast::DoubleType *node)
-    {
-        actual_type = node;
-    };
-    void Semantic::visit(ast::BoolType *node)
-    {
-        actual_type = node;
-    };
-    void Semantic::visit(ast::ArrayType *node)
-    {
-        if (node->size)
-        {
-            node->size->accept(this);
-        }
-        if (node->dtype)
-        {
-            node->dtype->accept(this);
-        }
-        actual_type = node;
-    };
-    void Semantic::visit(ast::RecordType *node)
-    {
-        for (auto field : node->fields)
-        {
-            if (field)
-            {
-                field->accept(this);
-            }
-        }
-        actual_type = node;
-    };
-    void Semantic::visit(ast::IntLiteral *node)
-    {
-        actual_type = new ast::IntType();
-    };
-    void Semantic::visit(ast::DoubleLiteral *node)
-    {
-        actual_type = new ast::DoubleType();
-    };
-    void Semantic::visit(ast::BoolLiteral *node)
-    {
-        actual_type = new ast::BoolType();
-    };
-    void Semantic::visit(ast::BinaryExpression *node)
+    void Semantic::visitAssignment(ast::Assignment *node)
     {
         ast::Type *lhs_type;
-        if (node->lhs)
+        if (node->var)
         {
-            node->lhs->accept(this);
+            node->var->accept(this);
         }
         lhs_type = actual_type;
         ast::Type *rhs_type;
-        if (node->rhs)
+        if (node->expr)
         {
-            node->rhs->accept(this);
+            node->expr->accept(this);
         }
         rhs_type = actual_type;
         typecheck_types(lhs_type, rhs_type);
-        actual_type = lhs_type;
+        std::cout <<node->var->name << '\n';
+        std::cout<<type_to_string(lhs_type) << ' ' << type_to_string(rhs_type) << '\n';
     };
-    void Semantic::visit(ast::BitwiseExpression *node)
+    void Semantic::visitRoutineCall(ast::RoutineCall *node)
     {
-        ast::Type *lhs_type;
-        if (node->lhs)
-        {
-            node->lhs->accept(this);
-        }
-        lhs_type = actual_type;
-        ast::Type *rhs_type;
-        if (node->rhs)
-        {
-            node->rhs->accept(this);
-        }
-        rhs_type = actual_type;
-        typecheck_types(lhs_type, rhs_type);
-        actual_type = lhs_type;
-    };
-    void Semantic::visit(ast::ComparisonExpression *node)
-    {
-        ast::Type *lhs_type;
-        if (node->lhs)
-        {
-            node->lhs->accept(this);
-        }
-        lhs_type = actual_type;
-        ast::Type *rhs_type;
-        if (node->rhs)
-        {
-            node->rhs->accept(this);
-        }
-        rhs_type = actual_type;
-        typecheck_types(lhs_type, rhs_type);
-        actual_type = new ast::BoolType();
-    };
-    void Semantic::visit(ast::Assignment *node)
-    {
-        ast::Type *lhs_type;
-        if (node->modifiablePrimary)
-        {
-            node->modifiablePrimary->accept(this);
-        }
-        lhs_type = actual_type;
-        ast::Type *rhs_type;
-        if (node->expression)
-        {
-            node->expression->accept(this);
-        }
-        rhs_type = actual_type;
-        typecheck_types(lhs_type, rhs_type);
-    };
-    void Semantic::visit(ast::Print *node)
-    {
-        if (node->exp)
-        {
-            node->exp->accept(this);
-        }
-    };
-    void Semantic::visit(ast::Return *node) // TODO
-    {
-        // TODO type check exp with return type of current routine if exists
-        if (node->exp)
-        {
-            if(node->exp->dtype){
-                routine_return_type = node->exp->dtype;
-            }
-            node->exp->accept(this);
-        }
-    };
-    void Semantic::visit(ast::ModifiablePrimary *node)
-    {
-        if (varDeclSymbolTable.find(node->name) == varDeclSymbolTable.end())
+        if (routineDeclTable.find(node->name) == routineDeclTable.end())
         {
             err_undefined_obj(node->name);
         }
-        auto current_type = varDeclSymbolTable[node->name];
-        for (auto AV : node->accessValues)
-        {
-            if (std::holds_alternative<ast::node_ptr<ast::Expression>>(AV))
-            {
-                // check that we're trying to access an array
-                std::string got_type = type_to_string(current_type);
-                if (got_type.substr(0, 5) != "Array")
-                {
-                    err_expected_got(got_type, "Array");
-                    break;
-                }
-                else
-                {
-                    auto access_value = std::get<ast::node_ptr<ast::Expression>>(AV);
-                    access_value->accept(this);
-                    typecheck_types(actual_type, new ast::IntType());
-                    auto casted_type = static_cast<ast::ArrayType *>(current_type);
-                    current_type = &(*casted_type->dtype);
-                }
-            }
-            else
-            {
-                // check that we're trying to access a record and that this field exists
-                std::string field_name = std::get<std::string>(AV);
-                std::string got_type = type_to_string(current_type);
-                if (got_type.substr(0, 6) != "Record")
-                {
-                    err_expected_got(got_type, "Record");
-                    break;
-                }
-                else
-                {
-                    auto casted_type = static_cast<ast::RecordType *>(current_type);
-                    bool found_field = false;
-                    for (auto field : casted_type->fields)
-                    {
-                        if (field->name == field_name)
-                        {
-                            found_field = true;
-                            current_type = &(*field->dtype);
-                        }
+        // for (auto arg : node->args->exprs)
+        // {
+        //     if (arg)
+        //     {
+        //         arg->accept(this);
+                
+        //     }
+        // }
+        auto routine = routineDeclTable[node->name];
+        int size1 = 0, size2 = 0;
+        if(node->args){
+            size1 = node->args->exprs.size();
+        }
+        if(routine->params){
+            size2 = routine->params->decls.size();
+        }
+        if(size1 != size2){
+            err_wrong_params_number(size1, size2);
+        }
+        if(node->args && routine->params){
+            for (int i = 0; i < node->args->exprs.size(); i++){
+                if(routine->params->decls[i]->type && node->args->exprs[i]){
+                    if(node->args->exprs[i]){
+                        actual_type = nullptr;
+                        node->args->exprs[i]->accept(this);
                     }
-                    if (!found_field)
-                    {
-                        err_undefined_obj(field_name);
-                        break;
+                    if(actual_type){
+                        typecheck_types(actual_type,routine->params->decls[i]->type);
                     }
                 }
             }
         }
-        actual_type = current_type;
     };
-    void Semantic::visit(ast::IfStatement *node)
+    void Semantic::visitReturn(ast::Return *node)
+    {
+        if (node->expr)
+        {
+            if(node->expr){
+                actual_type = nullptr;
+                node->expr->accept(this);
+            }
+            if(actual_type){
+                routine_return_type = actual_type;
+            }
+        }
+    };
+
+    void Semantic::visitIf(ast::If *node)
     {
         ast::Type *cond_type;
         if (node->condition)
@@ -340,17 +256,17 @@ namespace analyzer
             node->condition->accept(this);
         }
         cond_type = actual_type;
-        typecheck_types(cond_type, new ast::BoolType());
-        if (node->ifBody)
+        typecheck_types(cond_type, new ast::BooleanType());
+        if (node->then)
         {
-            node->ifBody->accept(this);
+            node->then->accept(this);
         }
-        if (node->elseBody)
+        if (node->else_)
         {
-            node->elseBody->accept(this);
+            node->else_->accept(this);
         }
     };
-    void Semantic::visit(ast::WhileLoop *node)
+    void Semantic::visitWhileLoop(ast::WhileLoop *node)
     {
         ast::Type *cond_type;
         if (node->condition)
@@ -358,15 +274,24 @@ namespace analyzer
             node->condition->accept(this);
         }
         cond_type = actual_type;
-        typecheck_types(cond_type, new ast::BoolType());
-        if (node->loopBody)
+        typecheck_types(cond_type, new ast::BooleanType());
+        if (node->body)
         {
-            node->loopBody->accept(this);
+            node->body->accept(this);
         }
     };
-    void Semantic::visit(ast::ForLoop *node)
+    void Semantic::visitForLoop(ast::ForLoop *node)
     {
-        varDeclSymbolTable[node->identifier] = new ast::IntType();
+        varDeclSymbolTable[node->name] = new ast::IntegerType();
+        if(node->range){
+            node->range->accept(this);
+        }
+        if (node->body)
+        {
+            node->body->accept(this);
+        }
+    };
+    void Semantic::visitRange(ast::Range* node){
         ast::Type *fromType;
         if (node->from)
         {
@@ -379,48 +304,182 @@ namespace analyzer
             node->to->accept(this);
         }
         toType = actual_type;
-        typecheck_types(fromType, new ast::IntType());
-        typecheck_types(toType, new ast::IntType());
-        if (node->loopBody)
-        {
-            node->loopBody->accept(this);
-        }
-    };
-    // void Semantic::visit(ast::ForeachLoop *node) // TODO
-    // {
-    //     // TODO remove foreach loop from all places
-    //     if (node->modifiablePrimary)
-    //     {
-    //         node->modifiablePrimary->accept(this);
-    //     }
-    //     if (node->loopBody)
-    //     {
-    //         node->loopBody->accept(this);
-    //     }
-    // };
-    void Semantic::visit(ast::RoutineCall *node)
+        typecheck_types(fromType, new ast::IntegerType());
+        typecheck_types(toType, new ast::IntegerType());
+    }
+    void Semantic::visitPrint(ast::Print *node)
     {
-        if (routineDeclTable.find(node->name) == routineDeclTable.end())
+        if (node->expr)
         {
-            err_undefined_obj(node->name);
-        }
-        for (auto arg : node->args)
-        {
-            if (arg)
-            {
-                arg->accept(this);
-                
-            }
-        }
-        auto routine = routineDeclTable[node->name];
-        if(routine->params.size() != node->args.size()){
-            err_wrong_params_number(node->args.size(), routine->params.size());
-        }
-        for (int i = 0; i < node->args.size(); i++){
-            if(routine->params[i]->dtype && node->args[i]->dtype){
-                typecheck_types( &(*node->args[i]->dtype),&(*routine->params[i]->dtype));
-            }
+             node->expr->accept(this);
         }
     };
 
+    void Semantic::visitIntegerType(ast::IntegerType *node)
+    {
+        actual_type = node;
+    };
+    void Semantic::visitRealType(ast::RealType *node)
+    {
+        actual_type = node;
+    };
+    void Semantic::visitBooleanType(ast::BooleanType *node)
+    {
+        actual_type = node;
+    };
+    void Semantic::visitArrayType(ast::ArrayType *node)
+    {
+        if (node->size)
+        {
+            node->size->accept(this);
+        }
+        if (node->type)
+        {
+            node->type->accept(this);
+        }
+        actual_type = node;
+    };
+    void Semantic::visitRecordType(ast::RecordType *node)
+    {
+        for (auto field : node->decls->vars)
+        {
+            if (field)
+            {
+                field->accept(this);
+            }
+        }
+        actual_type = node;
+    };
+    
+    void Semantic::visitBinaryExpr(ast::BinaryExpr *node)
+    {
+        ast::Type *lhs_type;
+        if (node->left)
+        {
+            node->left->accept(this);
+        }
+        lhs_type = actual_type;
+        ast::Type *rhs_type;
+        if (node->right)
+        {
+            node->right->accept(this);
+        }
+        rhs_type = actual_type;
+        typecheck_types(lhs_type, rhs_type);
+        actual_type = lhs_type;
+    };
+    void Semantic::visitLogicExpr(ast::LogicExpr *node)
+    {
+        ast::Type *lhs_type;
+        if (node->left)
+        {
+            node->left->accept(this);
+        }
+        lhs_type = actual_type;
+        ast::Type *rhs_type;
+        if (node->right)
+        {
+            node->right->accept(this);
+        }
+        rhs_type = actual_type;
+        typecheck_types(lhs_type, rhs_type);
+        actual_type = lhs_type;
+    };
+    void Semantic::visitComparisonExpr(ast::ComparisonExpr *node)
+    {
+        ast::Type *lhs_type;
+        if (node->left)
+        {
+            node->left->accept(this);
+        }
+        lhs_type = actual_type;
+        ast::Type *rhs_type;
+        if (node->right)
+        {
+            node->right->accept(this);
+        }
+        rhs_type = actual_type;
+        typecheck_types(lhs_type, rhs_type);
+        actual_type = new ast::BooleanType();
+    };
+    void Semantic::visitIntegerValue(ast::IntegerValue* node)
+    {
+        actual_type = new ast::IntegerType();
+    };
+    void Semantic::visitRealValue(ast::RealValue* node)
+    {
+        actual_type = new ast::RealType();
+    };
+    void Semantic::visitBooleanValue(ast::BooleanValue* node)
+    {
+        actual_type = new ast::BooleanType();
+    };
+
+    void Semantic::visitVar(ast::Var *node)
+    {
+        if (varDeclSymbolTable.find(node->name) == varDeclSymbolTable.end())
+        {
+            err_undefined_obj(node->name);
+        }
+        current_var_type = varDeclSymbolTable[node->name];
+        //std::cout<<"I'm current var type: " << type_to_string(current_var_type) << '\n';
+        if(node->accesses){
+            for (auto AV : node->accesses->accesses)
+            {
+                if(AV)
+                    AV->accept(this);
+            }
+        }
+        //std::cout<< node->name << '\n';
+        //std::cout<<"I'm current var type: " << type_to_string(current_var_type) << '\n';
+        actual_type = current_var_type;
+    };
+    void Semantic::visitArrayAccess(ast::ArrayAccess* node){
+        // check that we're trying to access an array
+        auto my_current_type = current_var_type;
+        std::string got_type = type_to_string(my_current_type);
+        if (got_type.substr(0, 5) != "Array")
+        {
+            err_expected_got(got_type, "Array");
+        }
+        else
+        {
+            auto access_value = node->index;
+            access_value->accept(this);
+            typecheck_types(actual_type, new ast::IntegerType());
+            if(auto casted_type = dynamic_cast<ast::ArrayType *>(my_current_type)){
+                current_var_type = casted_type->type;
+                std::cout<<"current var type : " << type_to_string(my_current_type) << '\n';
+            }
+        }
+
+    }
+    void Semantic::visitRecordAccess(ast::RecordAccess* node){
+        // check that we're trying to access a record and that this field exists
+        auto my_current_type = current_var_type;
+        std::string field_name = node->name;
+        std::string got_type = type_to_string(my_current_type);
+        if (got_type.substr(0, 6) != "Record")
+        {
+            err_expected_got(got_type, "Record");
+        }
+        else
+        {
+            if(auto casted_type = dynamic_cast<ast::RecordType *>(my_current_type)){
+                bool found_field = false;
+                for (auto field : casted_type->decls->vars)
+                {
+                    if (field->name == field_name)
+                    {
+                        found_field = true;
+                        current_var_type = field->type;
+                    }
+                }
+                if (!found_field)
+                {
+                    err_undefined_obj(field_name);
+                }
+            }
+        }
+    }
 }

--- a/semantic.hpp
+++ b/semantic.hpp
@@ -38,7 +38,7 @@ namespace analyzer
         void visitIntegerValue(ast::IntegerValue *p);
         void visitRealValue(ast::RealValue *p);
         void visitBooleanValue(ast::BooleanValue *p);
-        void visitRoutineCallValue(ast::RoutineCallValue *p){} // not implemented
+        void visitRoutineCallValue(ast::RoutineCallValue *p);
         
         void visitType(ast::Type *p){}
         void visitPrimitiveType(ast::PrimitiveType *p){}

--- a/semantic.hpp
+++ b/semantic.hpp
@@ -86,7 +86,7 @@ namespace analyzer
 
         void err_expected_got(std::string expected, std::string got)
         {
-            std::cout << "Error: Expected: " << expected << ", got: " << got << '\n';
+            std::cout << "Error: Expected:\n" << expected << ",\ngot: \n" << got << '\n';
             exit(0);
         }
         void err_wrong_params_number(int expected, int got){
@@ -97,6 +97,7 @@ namespace analyzer
         {
             std::cout << "Warning: Shadowing object: " << obj << '\n';
         }
+        // Utility function to print expected/got type
         std::string type_to_string(ast::Type *type)
         {
             if (type == nullptr){
@@ -118,6 +119,8 @@ namespace analyzer
                 for (auto decl : type_record->decls->vars)
                 {
                     type_string += '\n';
+                    type_string += decl->name;
+                    type_string += ' ';
                     type_string += type_to_string(&(*decl->type));
                 }
                 type_string += "}";
@@ -127,24 +130,12 @@ namespace analyzer
         }
         void typecheck_types(ast::Type *type1, ast::Type *type2)
         {
+            if((*type1) == (*type2) )
+                return;
             std::string first = type_to_string(type1),
                         second = type_to_string(type2);
-            if (first != second)
-                err_expected_got(first, second);
+            err_expected_got(first, second);
         }
-        // ast::Type* TypePointerToShared(ast::Type* type){
-        //     if (auto type_int = dynamic_cast<ast::IntegerType *>(type))
-        //         return new ast::IntegerType(*type_int);
-        //     if (auto type_double = dynamic_cast<ast::RealType *>(type))
-        //         return new ast::RealType(*type_double);
-        //     if (auto type_bool = dynamic_cast<ast::BooleanType *>(type))
-        //         return new ast::BooleanType(*type_bool);
-        //     if (auto type_array = dynamic_cast<ast::ArrayType *>(type))
-        //         return new ast::ArrayType(*type_array);
-        //     if (auto type_record = dynamic_cast<ast::RecordType *>(type))
-        //        return new ast::RecordType(*type_record);
-        //     return nullptr;
-        // }
         void testing()
         {
             ast::Type *test = new ast::IntegerType();

--- a/semantic.hpp
+++ b/semantic.hpp
@@ -84,12 +84,12 @@ namespace analyzer
             exit(0);
         }
 
-        void err_expected_got(std::string got, std::string expected)
+        void err_expected_got(std::string expected, std::string got)
         {
             std::cout << "Error: Expected: " << expected << ", got: " << got << '\n';
             exit(0);
         }
-        void err_wrong_params_number(int got, int expected){
+        void err_wrong_params_number(int expected, int got){
             std::cout << "Error: Expected number of params: " << expected << " got: " << got << '\n';
             exit(0);
         }

--- a/semantic.hpp
+++ b/semantic.hpp
@@ -76,22 +76,22 @@ namespace analyzer
         ast::Type* current_var_type = nullptr;
         void err_second_declaration(std::string name){
             std::cout << "Error: second declaration of " << name << " is invalid.\n";
-            exit(0);
+            exit(1);
         }
         void err_undefined_obj(std::string obj)
         {
             std::cout << "Error: Undefined object: " << obj << '\n';
-            exit(0);
+            exit(1);
         }
 
         void err_expected_got(std::string expected, std::string got)
         {
             std::cout << "Error: Expected:\n" << expected << ",\ngot: \n" << got << '\n';
-            exit(0);
+            exit(1);
         }
         void err_wrong_params_number(int expected, int got){
             std::cout << "Error: Expected number of params: " << expected << " got: " << got << '\n';
-            exit(0);
+            exit(1);
         }
         void warn_shadow(std::string obj)
         {

--- a/test.crbc
+++ b/test.crbc
@@ -1,11 +1,11 @@
 routine main () : integer is 
     var x : record 
-        var a : integer is 2;
+        var a : integer is 5;
         var b : integer is 3;
     end;
     var y : record 
-        var c : integer is 4;
-        var d : integer is 0;
+        var b : integer is 0;
+        var a : integer is 4;
     end;
     x := y;
     print(x.a);

--- a/test.crbc
+++ b/test.crbc
@@ -1,8 +1,10 @@
 routine main () : integer is 
-    var x : integer is 0;
-    
-    if true then 
-        var x : integer is 1; //shadowing
+    for i in true .. false loop
+        print(i);
+    end
+
+    for i in reverse 0 .. 3 loop
+        print(i);
     end
 
     return 0;

--- a/test.crbc
+++ b/test.crbc
@@ -1,15 +1,9 @@
-routine main () : integer is 
-    var x : record 
-        var a : integer is 5;
-        var b : integer is 3;
+routine  main() : integer is 
+    var x : integer is 5;
+    var y : integer is 3;
+    var z : record
+        var x : boolean is false;
+        var y : integer is 1;
     end;
-    var y : record 
-        var b : integer is 0;
-        var a : integer is 4;
-    end;
-    x := y;
-    print(x.a);
-    print(x.b);
-
-    return 0;
+    return z.x;
 end

--- a/test.crbc
+++ b/test.crbc
@@ -4,7 +4,7 @@ routine main () : integer is
     end
 
     for i in reverse 0 .. 3 loop
-        print(i);
+        print(j);
     end
 
     return 0;

--- a/test.crbc
+++ b/test.crbc
@@ -1,11 +1,15 @@
 routine main () : integer is 
-    for i in true .. false loop
-        print(i);
-    end
-
-    for i in reverse 0 .. 3 loop
-        print(j);
-    end
+    var x : record 
+        var a : integer is 2;
+        var b : integer is 3;
+    end;
+    var y : record 
+        var c : integer is 4;
+        var d : integer is 0;
+    end;
+    x := y;
+    print(x.a);
+    print(x.b);
 
     return 0;
 end

--- a/tests/inputs/invalid/syntax/undefined_routine.crbc
+++ b/tests/inputs/invalid/syntax/undefined_routine.crbc
@@ -1,4 +1,4 @@
-routine div (x : real, y : real) : integer is 
+routine div (x : real, y : real) : real is 
     
     var z : real;
     z := x / y;

--- a/tests/inputs/invalid/syntax/undefined_routine.crbc
+++ b/tests/inputs/invalid/syntax/undefined_routine.crbc
@@ -8,7 +8,7 @@ end
 
 routine main () : integer is 
     
-    var x : real is div( 4.4 , 2.2 );
+    var x : real is divide( 4.4 , 2.2 );
 
     if x > 1.1 then
         print(1);

--- a/tests/inputs/invalid/syntax/undefined_var.crbc
+++ b/tests/inputs/invalid/syntax/undefined_var.crbc
@@ -1,7 +1,7 @@
-routine div (x : real, y : real) : integer is 
+routine div (x : real, y : real) is 
     
     var z : real;
-    z := x / y;
+    z := x / b;
 
     return z;
 end


### PR DESCRIPTION
Main changes:
Semantics:
   1) Typechecking was changed from depending on strings to overloading the == operator of types and be able to easily compare them -> most useful for user defined types like arrays and records
   2) Some utility functions were added to cleanup semantics visitor and make it more easily understandable
   3) Typecheck error messages were fixed (there was a problem in expected, got)
Pretty printer:
   1) Add pretty printer method and reverse flag for range
Tests:
   1) More bad tests