### PR TITLE
[add] partial builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,11 @@ clean:
 	rm -rf tests/outputs
 	rm -f output.txt
 
-build:
-	mkdir build
+build: build/all
+	cd build && make
+
+build/all:
+	mkdir -p build
 	cd build && cmake .. && make
 
 run: build


### PR DESCRIPTION
Changed `make build` command to perform a partial build only on changed files. The old functionality of re-building the entire project is now under `make build/all`