### PR TITLE
[fix] .PHONY for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,20 @@ clean:
 	rm -rf tests/outputs
 	rm -f output.txt
 
-build: build/all
-	cd build && make
+.PHONY: build
 
-build/all:
+BUILD_ALL_RUN := $(shell if [ -f build/CMakeCache.txt ]; then echo "1"; else echo "0"; fi)
+
+build:
+    ifeq ($(BUILD_ALL_RUN),1)
+	$(info build/all has been run before. Running partial build...)
+	cd build && make
+    else 
+	$(info build/all has not been run before. Running build/all...)
+	$(MAKE) build/all
+    endif
+
+build/all: clean
 	mkdir -p build
 	cd build && cmake .. && make
 


### PR DESCRIPTION
`build` and `build/all` did not have the expected behavior because the .PHONY was missing for `build`. Should be good now.